### PR TITLE
Fix transposition of DIDs in presentation requests

### DIFF
--- a/proof-configurations/accredited-lawyer/prod/accredited-lawyer-bcpc.json
+++ b/proof-configurations/accredited-lawyer/prod/accredited-lawyer-bcpc.json
@@ -28,7 +28,7 @@
         ],
         "restrictions": [
           {
-            "issuer_did": "KCxVC8GkKywjhWJnUfCmkW",
+            "issuer_did": "RGjWbW1eycP7FrMf4QJvX8",
             "schema_name": "Person",
             "schema_version": "1.0"
           }

--- a/proof-configurations/accredited-lawyer/test/accredited-lawyer-bcpc.json
+++ b/proof-configurations/accredited-lawyer/test/accredited-lawyer-bcpc.json
@@ -38,7 +38,7 @@
         ],
         "restrictions": [
           {
-            "issuer_did": "RGjWbW1eycP7FrMf4QJvX8",
+            "issuer_did": "KCxVC8GkKywjhWJnUfCmkW",
             "schema_name": "Person",
             "schema_version": "1.0"
           },


### PR DESCRIPTION
- Fix transposition of DIDs in the `test` and `prod` versions of the `accredited-lawyer-bcpc` presentation requests.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>