### PR TITLE
Upgraded issuer-api base image to use Node 18

### DIFF
--- a/openshift/templates/issuer-api/issuer-api-build.yaml
+++ b/openshift/templates/issuer-api/issuer-api-build.yaml
@@ -106,7 +106,7 @@ parameters:
     displayName: Source Image Name
     required: true
     description: The name of the source image.
-    value: centos/nodejs-12-centos7
+    value: quay.io/fedora/nodejs-18
   - name: SOURCE_IMAGE_TAG
     displayName: Source Image Tag
     required: true


### PR DESCRIPTION
Signed-off-by: Emiliano Suñé <emiliano.sune@gmail.com>