### PR TITLE
Set to single (tools namspace) ledger for Sandbox

### DIFF
--- a/helm-values/traction/values-sandbox.yaml
+++ b/helm-values/traction/values-sandbox.yaml
@@ -7,6 +7,13 @@ acapy:
       generated: true
     pluginInnkeeper:
       generated: true
+  ledgers.yml:
+    - id: bcovrin-test
+      is_production: true
+      is_write: true
+      genesis_url: 'http://test.bcovrin.vonx.io/genesis'
+      endorser_did: 'Ket75eV5UQvVkW2XBjgDH7'
+      endorser_alias: 'bcovrin-test-endorser'
   plugin-config.yml:
     traction_innkeeper:
       innkeeper_wallet:


### PR DESCRIPTION
Use the **Ket75eV5UQvVkW2XBjgDH7** endorser that runs in bc0192-tools for the Sandbox environment.
Only allow bcovrin-test as an option
That endorser is auto-everything.