### PR TITLE
[vc-authn-oidc] Set mongodb resource requests, limits, and adjust probes

### DIFF
--- a/helm-values/vc-authn-oidc/dev.yaml
+++ b/helm-values/vc-authn-oidc/dev.yaml
@@ -90,3 +90,17 @@ acapy:
       enabled: true
       namespaceSelector:
         network.openshift.io/policy-group: ingress
+mongodb:
+  resources:
+    limits:
+      cpu: 300m
+      memory: 1000Mi
+    requests:
+      cpu: 40m
+      memory: 450Mi
+  readinessProbe:
+    enabled: true
+    timeoutSeconds: 10
+  livenessProbe:
+    enabled: true
+    timeoutSeconds: 10

--- a/helm-values/vc-authn-oidc/prod.yaml
+++ b/helm-values/vc-authn-oidc/prod.yaml
@@ -90,3 +90,18 @@ acapy:
       enabled: true
       namespaceSelector:
         network.openshift.io/policy-group: ingress
+
+mongodb:
+  resources:
+    limits:
+      cpu: 300m
+      memory: 1000Mi
+    requests:
+      cpu: 40m
+      memory: 450Mi
+  readinessProbe:
+    enabled: true
+    timeoutSeconds: 10
+  livenessProbe:
+    enabled: true
+    timeoutSeconds: 10

--- a/helm-values/vc-authn-oidc/test.yaml
+++ b/helm-values/vc-authn-oidc/test.yaml
@@ -90,3 +90,18 @@ acapy:
       enabled: true
       namespaceSelector:
         network.openshift.io/policy-group: ingress
+
+mongodb:
+  resources:
+    limits:
+      cpu: 300m
+      memory: 1000Mi
+    requests:
+      cpu: 40m
+      memory: 450Mi
+  readinessProbe:
+    enabled: true
+    timeoutSeconds: 10
+  livenessProbe:
+    enabled: true
+    timeoutSeconds: 10


### PR DESCRIPTION
`vc-authn-mongo` statefulsets in `dev`, `test`, and `prod` seem to have an issue with Readiness probe command timing out.
The timeout is not very consistent but still results in sporadic pod restarts.
Found a related issue https://github.com/bitnami/charts/issues/10264 

This PR addresses the issue.
- Specify resource requests and limits for `mongodb` statefulsets
- Adjust `readinessProbe.timeoutSeconds` to `10` to avoid timeout