### PR TITLE
Add ledgers for candy and sovrin

### DIFF
--- a/helm-values/traction/values-test.yaml
+++ b/helm-values/traction/values-test.yaml
@@ -9,6 +9,18 @@ acapy:
       genesis_url: "http://test.bcovrin.vonx.io/genesis"
       endorser_did: "4pgFAjnSVKCr7CMfpqDjhu"
       endorser_alias: "bcovrin-test-endorser"
+    - id: candy-test
+      is_production: true
+      is_write: true
+      genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/test/pool_transactions_genesis"
+      endorser_did: "8pcyugH47GpPocmz9AxxDF"
+      endorser_alias: "candy-test-endorser"
+    - id: sovrin-testnet
+      is_production: true
+      is_write: true
+      genesis_url: "https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis"
+      endorser_did: "EZpKx6nT56Hv83JmNz7ik8"
+      endorser_alias: "sovrin-testnet-endorser"
   plugin-config.yml:
     traction_innkeeper:
       innkeeper_wallet:
@@ -17,8 +29,14 @@ acapy:
         connect_to_endorser:
           - endorser_alias: bcovrin-test-endorser
             ledger_id: bcovrin-test
+          - endorser_alias: candy-test-endorser
+            ledger_id: candy-test
+          - endorser_alias: sovrin-testnet-endorser
+            ledger_id: sovrin-testnet
         create_public_did:
           - bcovrin-test
+          - candy-test
+          - sovrin-testnet
       reservation:
         expiry_minutes: 2880
         auto_approve: false


### PR DESCRIPTION
Add the following ledgers/endorsers, and set to Innkeeper approval for tenants

- Candy-test
- sovrin testnet

Both endorsers are in `4a9599-test`