### PR TITLE
Disable write components in prod

### DIFF
--- a/helm-values/traction/values-production.yaml
+++ b/helm-values/traction/values-production.yaml
@@ -72,6 +72,7 @@ ui:
   oidc:
     active: true
     showInnkeeperAdminLogin: true
+    showWritableComponents: false
     authority: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm
     jwksUri: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm/protocol/openid-connect/certs
     reservationForm: >-


### PR DESCRIPTION
Set the `showWritableComponents` flag for the tenant UI to false in prod.

I noticed this is under the `oidc` block, which isn't really the right place for it. But will fix that up later because we'll have to have a different helm/Traction release to move it.