### PR TITLE
Change OIDC provider for Tenant UI

### DIFF
--- a/helm-values/traction/values-production.yaml
+++ b/helm-values/traction/values-production.yaml
@@ -73,8 +73,8 @@ ui:
     active: true
     showInnkeeperAdminLogin: true
     showWritableComponents: false
-    authority: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm
-    jwksUri: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm/protocol/openid-connect/certs
+    authority: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
+    jwksUri: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
     reservationForm: >-
       {
         "formDataSchema": {

--- a/helm-values/traction/values-production.yaml
+++ b/helm-values/traction/values-production.yaml
@@ -75,6 +75,7 @@ ui:
     showWritableComponents: false
     authority: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
     jwksUri: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
+    realm: "digitaltrust-citz"
     reservationForm: >-
       {
         "formDataSchema": {

--- a/helm-values/traction/values-sandbox.yaml
+++ b/helm-values/traction/values-sandbox.yaml
@@ -70,6 +70,7 @@ ui:
     showWritableComponents: true
     authority: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
     jwksUri: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
+    realm: "digitaltrust-citz"
     reservationForm: >-
       {
         "formDataSchema": {

--- a/helm-values/traction/values-sandbox.yaml
+++ b/helm-values/traction/values-sandbox.yaml
@@ -68,8 +68,8 @@ ui:
     active: false
     showInnkeeperAdminLogin: true
     showWritableComponents: true
-    authority: ""
-    jwksUri: ""
+    authority: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
+    jwksUri: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
     reservationForm: >-
       {
         "formDataSchema": {

--- a/helm-values/traction/values-sandbox.yaml
+++ b/helm-values/traction/values-sandbox.yaml
@@ -68,8 +68,8 @@ ui:
     active: false
     showInnkeeperAdminLogin: true
     showWritableComponents: true
-    authority: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
-    jwksUri: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
+    authority: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
+    jwksUri: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
     realm: "digitaltrust-citz"
     reservationForm: >-
       {

--- a/helm-values/traction/values-test.yaml
+++ b/helm-values/traction/values-test.yaml
@@ -88,8 +88,8 @@ ui:
   oidc:
     active: true
     showInnkeeperAdminLogin: true
-    authority: https://test.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm
-    jwksUri: https://test.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm/protocol/openid-connect/certs
+    authority: https://test.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
+    jwksUri: https://test.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
     reservationForm: >-
       {
         "formDataSchema": {

--- a/helm-values/traction/values-test.yaml
+++ b/helm-values/traction/values-test.yaml
@@ -90,6 +90,7 @@ ui:
     showInnkeeperAdminLogin: true
     authority: https://test.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
     jwksUri: https://test.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
+    realm: "digitaltrust-citz"
     reservationForm: >-
       {
         "formDataSchema": {


### PR DESCRIPTION
Update OIDC provider so we can deprecate the digitaltrust-nrm realm.

This doesn't need to coincide with any release or any other planning, we could just deploy these values at any time. The new digitaltrust-citz realm is already set up with the required client and things.