### PR TITLE
Increase sandbox database PVC size to 5Gb

### DIFF
--- a/helm-values/traction/values-sandbox.yaml
+++ b/helm-values/traction/values-sandbox.yaml
@@ -116,10 +116,13 @@ ingress:
   annotations:
     route.openshift.io/termination: edge
 postgresql:
-  resources:
-    limits:
-      cpu: 400m
-      memory: 1600Mi
-    requests:
-      cpu: 200m
-      memory: 820Mi
+  primary:
+    persistence:
+      size: 5Gi
+    resources:
+      limits:
+        cpu: 400m
+        memory: 1600Mi
+      requests:
+        cpu: 200m
+        memory: 820Mi

--- a/helm-values/traction/values-sandbox.yaml
+++ b/helm-values/traction/values-sandbox.yaml
@@ -121,8 +121,8 @@ postgresql:
       size: 5Gi
     resources:
       limits:
-        cpu: 400m
-        memory: 1600Mi
+        cpu: 2
+        memory: 4000Mi
       requests:
         cpu: 200m
         memory: 820Mi


### PR DESCRIPTION
Increases the default PVC size for the sandbox to 5Gb to account for rapid db size increase (e.g.: when load testing). The pVC was manually updated in OCP so this will be applied at the next reset.
I also fixed the resource claim for postgres: it was not under the right key/indentation.