### PR TITLE
Adjust mandatory reservation fields

### DIFF
--- a/helm-values/traction/values-sandbox.yaml
+++ b/helm-values/traction/values-sandbox.yaml
@@ -59,6 +59,7 @@ tenant_proxy:
         network.openshift.io/policy-group: ingress
 ui:
   quickConnectEndorserName: "bcovrin-test-endorser"
+  requireEmailForReservation: false
   image:
     pullPolicy: Always
   ux:
@@ -79,8 +80,7 @@ ui:
             "organization": {
               "type": "string"
             }
-          },
-          "required": ["organization"]
+          }
         },
         "formUISchema": {
           "type": "VerticalLayout",


### PR DESCRIPTION
For the changes in https://github.com/bcgov/traction/pull/1023

Allow the Sandbox env tenants to leave email blank when creating a tenant. 
Also remove mandatory on the "Company" field.

Can take affect once a Traction and Helm release containing the relevant values is released.