### PR TITLE
Blank out and set text for sandbox governance link

### DIFF
--- a/helm-values/traction/values-sandbox.yaml
+++ b/helm-values/traction/values-sandbox.yaml
@@ -62,6 +62,9 @@ ui:
   image:
     pullPolicy: Always
   ux:
+    aboutBusiness:
+      linkTitle: "No service agreement available for Sandbox environment"
+      link: " "
     infoBanner:
       showMessage: true
   oidc:


### PR DESCRIPTION
For the changes for https://github.com/bcgov/DITP-DevOps/issues/144 supported by Tenant UI helm additions in https://github.com/bcgov/traction/pull/1024

In the Sandbox env, on the About page, set the Governance link text to "No service agreement available for Sandbox environment" and blank out the link