### PR TITLE
Add the KC idp hint to Traction envs

### DIFF
--- a/helm-values/traction/values-production.yaml
+++ b/helm-values/traction/values-production.yaml
@@ -75,6 +75,7 @@ ui:
     showWritableComponents: false
     authority: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
     jwksUri: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
+    extraQueryParams: '{"kc_idp_hint":"idir"}'
     realm: "digitaltrust-citz"
     reservationForm: >-
       {

--- a/helm-values/traction/values-sandbox.yaml
+++ b/helm-values/traction/values-sandbox.yaml
@@ -74,6 +74,7 @@ ui:
     showWritableComponents: true
     authority: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
     jwksUri: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
+    extraQueryParams: '{"kc_idp_hint":"idir"}'
     realm: "digitaltrust-citz"
     reservationForm: >-
       {

--- a/helm-values/traction/values-test.yaml
+++ b/helm-values/traction/values-test.yaml
@@ -90,6 +90,7 @@ ui:
     showInnkeeperAdminLogin: true
     authority: https://test.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
     jwksUri: https://test.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
+    extraQueryParams: '{"kc_idp_hint":"idir"}'
     realm: "digitaltrust-citz"
     reservationForm: >-
       {


### PR DESCRIPTION
Realized when using one of the non-dev Traction envs that I hadn't applied the setting that was added with this https://github.com/bcgov/traction/issues/961 that allows logins to go right to the IDIR page as desired with the existing BCGov setups (IDIR is required, other IDPs in the KC realm not supported for our configurations).

Add to sandbox, test, prod. Sorry for the string json, was needed to get it to go into the oidc lib appropriately.

No need or priority to deploy this, can just apply it and on next release pick it up.