### PR TITLE
Accept Person credential in dev/test environments for accredited lawyer proof

### DIFF
--- a/proof-configurations/accredited-lawyer/dev/accredited-lawyer-bcpc.json
+++ b/proof-configurations/accredited-lawyer/dev/accredited-lawyer-bcpc.json
@@ -57,6 +57,11 @@
             "issuer_did": "NCwGwDrzbZEqesYQummzWW",
             "schema_name": "unverified_person",
             "schema_version": "0.4.0"
+          },
+          {
+            "issuer_did": "RGjWbW1eycP7FrMf4QJvX8",
+            "schema_name": "Person",
+            "schema_version": "1.0"
           }
         ]
       }

--- a/proof-configurations/accredited-lawyer/test/accredited-lawyer-bcpc.json
+++ b/proof-configurations/accredited-lawyer/test/accredited-lawyer-bcpc.json
@@ -57,6 +57,11 @@
             "issuer_did": "8Yq7EhKBMujh25NkLGGb2t",
             "schema_name": "unverified_person",
             "schema_version": "0.4.0"
+          },
+          {
+            "issuer_did": "RGjWbW1eycP7FrMf4QJvX8",
+            "schema_name": "Person",
+            "schema_version": "1.0"
           }
         ]
       }


### PR DESCRIPTION
Adds production Person credential to accepted credentials in the accredited lawyer proof .
Already deployed to both `dev` and `test`.