### PR TITLE
Update dev/test vc-authn agents to support CANdy Prod

### DIFF
--- a/helm-values/vc-authn-oidc/dev.yaml
+++ b/helm-values/vc-authn-oidc/dev.yaml
@@ -37,7 +37,7 @@ networkPolicy:
 ingress:
   enabled: true
   annotations:
-   route.openshift.io/termination: edge
+    route.openshift.io/termination: edge
 
 acapy:
   image:
@@ -76,13 +76,16 @@ acapy:
     - id: SOVRINSandbox
       is_production: true
       is_write: true
-      genesis_url: 'https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis'
+      genesis_url: "https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis"
     - id: BCovrinTest
       is_production: true
-      genesis_url: 'http://test.bcovrin.vonx.io/genesis'
+      genesis_url: "http://test.bcovrin.vonx.io/genesis"
     - id: CANdyDev
       is_production: true
-      genesis_url: 'https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/dev/pool_transactions_genesis'
+      genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/dev/pool_transactions_genesis"
+    - id: CANdyProd
+      is_production: true
+      genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/prod/pool_transactions_genesis"
 
   networkPolicy:
     enabled: true

--- a/helm-values/vc-authn-oidc/test.yaml
+++ b/helm-values/vc-authn-oidc/test.yaml
@@ -37,7 +37,7 @@ networkPolicy:
 ingress:
   enabled: true
   annotations:
-   route.openshift.io/termination: edge
+    route.openshift.io/termination: edge
 
 acapy:
   image:
@@ -76,13 +76,16 @@ acapy:
     - id: SovrinStagingNet
       is_production: true
       is_write: true
-      genesis_url: 'https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis'
+      genesis_url: "https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis"
     - id: BCovrinTest
       is_production: true
-      genesis_url: 'http://test.bcovrin.vonx.io/genesis'
+      genesis_url: "http://test.bcovrin.vonx.io/genesis"
     - id: CANdyTest
       is_production: true
-      genesis_url: 'https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/test/pool_transactions_genesis'
+      genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/test/pool_transactions_genesis"
+    - id: CANdyProd
+      is_production: true
+      genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/prod/pool_transactions_genesis"
 
   networkPolicy:
     enabled: true


### PR DESCRIPTION
Changes have been deployed to both `dev` and `test`