### PR TITLE
Add proof-requests for SSO Pathfinder team sandbox

### DIFF
--- a/proof-configurations/showcase-person/dev/showcase-person.json
+++ b/proof-configurations/showcase-person/dev/showcase-person.json
@@ -22,15 +22,11 @@
                 "restrictions": [
                     {
                         "schema_name": "Person",
-                        "issuer_did": "L6ASjmDDbDH7yPL1t2yFj9"
-                    },
-                    {
-                        "schema_name": "Person",
-                        "issuer_did": "QEquAHkM35w4XVT3Ku5yat"
-                    },
-                    {
-                        "schema_name": "Person",
                         "issuer_did": "M6dhuFj5UwbhWkSLmvYSPc"
+                    },
+                    {
+                        "schema_name": "Person",
+                        "issuer_did": "RGjWbW1eycP7FrMf4QJvX8"
                     }
                 ]
             }

--- a/proof-configurations/sso-pathfinder/dev/sso-pathfinder-1.json
+++ b/proof-configurations/sso-pathfinder/dev/sso-pathfinder-1.json
@@ -1,0 +1,25 @@
+{
+    "ver_config_id": "sso-pathfinder-1",
+    "subject_identifier": "",
+    "generate_consistent_identifier": true,
+    "proof_request": {
+        "name": "SSO Pathfinder Proof Request 1",
+        "version": "1.0",
+        "requested_attributes": [
+            {
+                "names": [
+                    "given_name",
+                    "given_names",
+                    "family_name",
+                    "country"
+                ],
+                "restrictions": [
+                    {
+                        "issuer_did": "KStpBJeuwwouK289zCM6gr"
+                    }
+                ]
+            }
+        ],
+        "requested_predicates": []
+    }
+}

--- a/proof-configurations/sso-pathfinder/dev/sso-pathfinder-1.json
+++ b/proof-configurations/sso-pathfinder/dev/sso-pathfinder-1.json
@@ -1,7 +1,7 @@
 {
     "ver_config_id": "sso-pathfinder-1",
     "subject_identifier": "",
-    "generate_consistent_identifier": true,
+    "generate_consistent_identifier": false,
     "proof_request": {
         "name": "SSO Pathfinder Proof Request 1",
         "version": "1.0",

--- a/proof-configurations/sso-pathfinder/dev/sso-pathfinder-2.json
+++ b/proof-configurations/sso-pathfinder/dev/sso-pathfinder-2.json
@@ -1,7 +1,7 @@
 {
     "ver_config_id": "sso-pathfinder-2",
     "subject_identifier": "",
-    "generate_consistent_identifier": true,
+    "generate_consistent_identifier": false,
     "proof_request": {
         "name": "SSO Pathfinder Proof Request 2",
         "version": "1.0",

--- a/proof-configurations/sso-pathfinder/dev/sso-pathfinder-2.json
+++ b/proof-configurations/sso-pathfinder/dev/sso-pathfinder-2.json
@@ -1,0 +1,27 @@
+{
+    "ver_config_id": "sso-pathfinder-2",
+    "subject_identifier": "",
+    "generate_consistent_identifier": true,
+    "proof_request": {
+        "name": "SSO Pathfinder Proof Request 2",
+        "version": "1.0",
+        "requested_attributes": [
+            {
+                "names": [
+                    "given_names",
+                    "family_name",
+                    "locality",
+                    "region",
+                    "postal_code",
+                    "street_address"
+                ],
+                "restrictions": [
+                    {
+                        "issuer_did": "KStpBJeuwwouK289zCM6gr"
+                    }
+                ]
+            }
+        ],
+        "requested_predicates": []
+    }
+}


### PR DESCRIPTION
Added two proof-configurations that will be used by the SSO Pathfinder team to validate their integration with VC-AuthN.
Configurations have been deployed to VC-AuthN `dev`.