### PR TITLE
Update accredited-lawyer-dev proof configuration

### DIFF
--- a/proof-configurations/accredited-lawyer/dev/accredited-lawyer.json
+++ b/proof-configurations/accredited-lawyer/dev/accredited-lawyer.json
@@ -1,9 +1,10 @@
 {
-  "id": "accredited-lawyer-dev",
+  "ver_config_id": "accredited-lawyer-dev",
+  "include_v1_attributes": true,
   "subject_identifier": "PPID",
-  "configuration": {
-    "name": "accredited-lawyer",
-    "version": "1.5.2",
+  "proof_request": {
+    "name": "Accredited Lawyer",
+    "version": "1.5.3",
     "requested_attributes": [
       {
         "names": [


### PR DESCRIPTION
Updated the `accredited-lawyer-dev` proof configuration (without requirement for Person credential) to new structure and installed it in `dev` for Courthouse Libraries to use.