### PR TITLE
[helm] Update traction resource limits for test and prod.

### DIFF
--- a/helm-values/traction/values-production.yaml
+++ b/helm-values/traction/values-production.yaml
@@ -37,10 +37,10 @@ acapy:
         network.openshift.io/policy-group: ingress
   resources:
     limits:
-      cpu: 400m
+      cpu: 1
       memory: 500Mi
     requests:
-      cpu: 120m
+      cpu: 250m
       memory: 250Mi
   autoscaling:
     enabled: true

--- a/helm-values/traction/values-test.yaml
+++ b/helm-values/traction/values-test.yaml
@@ -61,6 +61,9 @@ acapy:
     maxReplicas: 5
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
+  resources:
+    limits:
+      cpu: 750m
 tenant_proxy:
   image:
     pullPolicy: Always


### PR DESCRIPTION
Increase resource limits for `test` and `prod` traction deployments.

Addresses: https://github.com/bcgov/DITP-DevOps/issues/181