### PR TITLE
Feature/courthouse proof request

### DIFF
--- a/proof-configurations/accredited-lawyer/dev/accredited-lawyer-bcpc.json
+++ b/proof-configurations/accredited-lawyer/dev/accredited-lawyer-bcpc.json
@@ -26,6 +26,21 @@
             "schema_version": "1.0.1"
           },
           {
+            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
+            "schema_name": "Member Certificate",
+            "schema_version": "0.5.0"
+          },
+          {
+            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
+            "schema_name": "Member Certificate",
+            "schema_version": "1.0.1"
+          },
+          {
+            "issuer_did": "AuJrigKQGRLJajKAebTgWu",
+            "schema_name": "Member Card",
+            "schema_version": "1.5.1"
+          },
+          {
             "issuer_did": "UUHA3oknprvKrpa7a6sncK",
             "schema_name": "Member Card",
             "schema_version": "1.5.1"
@@ -62,6 +77,11 @@
             "issuer_did": "RGjWbW1eycP7FrMf4QJvX8",
             "schema_name": "Person",
             "schema_version": "1.0"
+          },
+          {
+            "issuer_did": "4xE68b6S5VRFrKMMG1U95M",
+            "schema_name": "Member Card",
+            "schema_version": "1.5.1"
           }
         ]
       }

--- a/proof-configurations/accredited-lawyer/dev/accredited-lawyer-status.json
+++ b/proof-configurations/accredited-lawyer/dev/accredited-lawyer-status.json
@@ -1,0 +1,55 @@
+{
+  "ver_config_id": "accredited-lawyer-status-dev",
+  "include_v1_attributes": true,
+  "subject_identifier": "PPID",
+  "proof_request": {
+    "name": "Accredited Lawyer Status",
+    "version": "1.0.0",
+    "requested_attributes": [
+      {
+        "names": [
+          "Member Status",
+          "Member Status Code"
+        ],
+        "restrictions": [
+          {
+            "issuer_did": "RznYFPVhHpYZgsn4Hu3StV",
+            "schema_name": "Member Certificate",
+            "schema_version": "0.5.0"
+          },
+          {
+            "issuer_did": "RznYFPVhHpYZgsn4Hu3StV",
+            "schema_name": "Member Certificate",
+            "schema_version": "1.0.1"
+          },
+          {
+            "issuer_did": "UUHA3oknprvKrpa7a6sncK",
+            "schema_name": "Member Card",
+            "schema_version": "1.5.1"
+          },
+          {
+            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
+            "schema_name": "Member Certificate",
+            "schema_version": "0.5.0"
+          },
+          {
+            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
+            "schema_name": "Member Certificate",
+            "schema_version": "1.0.1"
+          },
+          {
+            "issuer_did": "AuJrigKQGRLJajKAebTgWu",
+            "schema_name": "Member Card",
+            "schema_version": "1.5.1"
+          },
+          {
+            "issuer_did": "4xE68b6S5VRFrKMMG1U95M",
+            "schema_name": "Member Card",
+            "schema_version": "1.5.1"
+          }
+        ]
+      }
+    ],
+    "requested_predicates": []
+  }
+}

--- a/proof-configurations/accredited-lawyer/dev/accredited-lawyer.json
+++ b/proof-configurations/accredited-lawyer/dev/accredited-lawyer.json
@@ -29,6 +29,26 @@
             "issuer_did": "UUHA3oknprvKrpa7a6sncK",
             "schema_name": "Member Card",
             "schema_version": "1.5.1"
+          },
+          {
+            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
+            "schema_name": "Member Certificate",
+            "schema_version": "0.5.0"
+          },
+          {
+            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
+            "schema_name": "Member Certificate",
+            "schema_version": "1.0.1"
+          },
+          {
+            "issuer_did": "AuJrigKQGRLJajKAebTgWu",
+            "schema_name": "Member Card",
+            "schema_version": "1.5.1"
+          },
+          {
+            "issuer_did": "4xE68b6S5VRFrKMMG1U95M",
+            "schema_name": "Member Card",
+            "schema_version": "1.5.1"
           }
         ]
       }

--- a/proof-configurations/accredited-lawyer/prod/accredited-lawyer-status.json
+++ b/proof-configurations/accredited-lawyer/prod/accredited-lawyer-status.json
@@ -1,0 +1,24 @@
+{
+  "ver_config_id": "accredited-lawyer-status",
+  "include_v1_attributes": true,
+  "subject_identifier": "PPID",
+  "proof_request": {
+    "name": "Accredited Lawyer Status",
+    "version": "1.0.0",
+    "requested_attributes": [
+      {
+        "names": [
+          "Member Status Code"
+        ],
+        "restrictions": [
+          {
+            "issuer_did": "4xE68b6S5VRFrKMMG1U95M",
+            "schema_name": "Member Card",
+            "schema_version": "1.5.1"
+          }
+        ]
+      }
+    ],
+    "requested_predicates": []
+  }
+}

--- a/proof-configurations/accredited-lawyer/test/accredited-lawyer-bcpc.json
+++ b/proof-configurations/accredited-lawyer/test/accredited-lawyer-bcpc.json
@@ -29,6 +29,11 @@
             "issuer_did": "AuJrigKQGRLJajKAebTgWu",
             "schema_name": "Member Card",
             "schema_version": "1.5.1"
+          },
+          {
+            "issuer_did": "4xE68b6S5VRFrKMMG1U95M",
+            "schema_name": "Member Card",
+            "schema_version": "1.5.1"
           }
         ]
       },

--- a/proof-configurations/accredited-lawyer/test/accredited-lawyer-status.json
+++ b/proof-configurations/accredited-lawyer/test/accredited-lawyer-status.json
@@ -1,0 +1,40 @@
+{
+  "ver_config_id": "accredited-lawyer-status-test",
+  "include_v1_attributes": true,
+  "subject_identifier": "PPID",
+  "proof_request": {
+    "name": "Accredited Lawyer Status",
+    "version": "1.0.0",
+    "requested_attributes": [
+      {
+        "names": [
+          "Member Status",
+          "Member Status Code"
+        ],
+        "restrictions": [
+          {
+            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
+            "schema_name": "Member Certificate",
+            "schema_version": "0.5.0"
+          },
+          {
+            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
+            "schema_name": "Member Certificate",
+            "schema_version": "1.0.1"
+          },
+          {
+            "issuer_did": "AuJrigKQGRLJajKAebTgWu",
+            "schema_name": "Member Card",
+            "schema_version": "1.5.1"
+          },
+          {
+            "issuer_did": "4xE68b6S5VRFrKMMG1U95M",
+            "schema_name": "Member Card",
+            "schema_version": "1.5.1"
+          }
+        ]
+      }
+    ],
+    "requested_predicates": []
+  }
+}

--- a/proof-configurations/accredited-lawyer/test/accredited-lawyer.json
+++ b/proof-configurations/accredited-lawyer/test/accredited-lawyer.json
@@ -28,6 +28,11 @@
             "issuer_did": "AuJrigKQGRLJajKAebTgWu",
             "schema_name": "Member Card",
             "schema_version": "1.5.1"
+          },
+          {
+            "issuer_did": "4xE68b6S5VRFrKMMG1U95M",
+            "schema_name": "Member Card",
+            "schema_version": "1.5.1"
           }
         ]
       }


### PR DESCRIPTION
- Updated existing accredited lawyer proof-requests to support production credential use in `dev`/`test`.
- Updated `dev` accredited lawyer  proof-requests to support credentials from the `test` issuer, with the objective of only having one issuer for test credentials.
- Added proof-request configurations that only require the lawyer status for use by Courthouse Libraries.

Changes have already been applied in `dev`, `test` and `prod`.