### PR TITLE
Clean-up accredited lawyer proof-configurations to remove old unused credentials

### DIFF
--- a/proof-configurations/accredited-lawyer/dev/accredited-lawyer-bcpc.json
+++ b/proof-configurations/accredited-lawyer/dev/accredited-lawyer-bcpc.json
@@ -4,7 +4,7 @@
   "subject_identifier": "PPID",
   "proof_request": {
     "name": "Accredited Lawyer with BC Person Credential",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "requested_attributes": [
       {
         "names": [
@@ -18,22 +18,17 @@
           {
             "issuer_did": "RznYFPVhHpYZgsn4Hu3StV",
             "schema_name": "Member Certificate",
-            "schema_version": "0.5.0"
-          },
-          {
-            "issuer_did": "RznYFPVhHpYZgsn4Hu3StV",
-            "schema_name": "Member Certificate",
             "schema_version": "1.0.1"
           },
           {
             "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
             "schema_name": "Member Certificate",
-            "schema_version": "0.5.0"
+            "schema_version": "1.0.1"
           },
           {
-            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
-            "schema_name": "Member Certificate",
-            "schema_version": "1.0.1"
+            "issuer_did": "UUHA3oknprvKrpa7a6sncK",
+            "schema_name": "Member Card",
+            "schema_version": "1.5.1"
           },
           {
             "issuer_did": "AuJrigKQGRLJajKAebTgWu",
@@ -41,7 +36,7 @@
             "schema_version": "1.5.1"
           },
           {
-            "issuer_did": "UUHA3oknprvKrpa7a6sncK",
+            "issuer_did": "4xE68b6S5VRFrKMMG1U95M",
             "schema_name": "Member Card",
             "schema_version": "1.5.1"
           }
@@ -54,16 +49,6 @@
         ],
         "restrictions": [
           {
-            "issuer_did": "XpgeQa93eZvGSZBZef3PHn",
-            "schema_name": "Person",
-            "schema_version": "1.0"
-          },
-          {
-            "issuer_did": "7xjfawcnyTUcduWVysLww5",
-            "schema_name": "Person",
-            "schema_version": "1.0"
-          },
-          {
             "issuer_did": "Ui6HA36FvN83cEtmYYHxrn",
             "schema_name": "unverified_person",
             "schema_version": "0.1.0"
@@ -74,14 +59,19 @@
             "schema_version": "0.4.0"
           },
           {
-            "issuer_did": "RGjWbW1eycP7FrMf4QJvX8",
+            "issuer_did": "XpgeQa93eZvGSZBZef3PHn",
             "schema_name": "Person",
             "schema_version": "1.0"
           },
           {
-            "issuer_did": "4xE68b6S5VRFrKMMG1U95M",
-            "schema_name": "Member Card",
-            "schema_version": "1.5.1"
+            "issuer_did": "7xjfawcnyTUcduWVysLww5",
+            "schema_name": "Person",
+            "schema_version": "1.0"
+          },
+          {
+            "issuer_did": "RGjWbW1eycP7FrMf4QJvX8",
+            "schema_name": "Person",
+            "schema_version": "1.0"
           }
         ]
       }

--- a/proof-configurations/accredited-lawyer/dev/accredited-lawyer-status.json
+++ b/proof-configurations/accredited-lawyer/dev/accredited-lawyer-status.json
@@ -4,7 +4,7 @@
   "subject_identifier": "PPID",
   "proof_request": {
     "name": "Accredited Lawyer Status",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "requested_attributes": [
       {
         "names": [
@@ -16,10 +16,10 @@
           {
             "issuer_did": "RznYFPVhHpYZgsn4Hu3StV",
             "schema_name": "Member Certificate",
-            "schema_version": "0.5.0"
+            "schema_version": "1.0.1"
           },
           {
-            "issuer_did": "RznYFPVhHpYZgsn4Hu3StV",
+            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
             "schema_name": "Member Certificate",
             "schema_version": "1.0.1"
           },
@@ -27,16 +27,6 @@
             "issuer_did": "UUHA3oknprvKrpa7a6sncK",
             "schema_name": "Member Card",
             "schema_version": "1.5.1"
-          },
-          {
-            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
-            "schema_name": "Member Certificate",
-            "schema_version": "0.5.0"
-          },
-          {
-            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
-            "schema_name": "Member Certificate",
-            "schema_version": "1.0.1"
           },
           {
             "issuer_did": "AuJrigKQGRLJajKAebTgWu",

--- a/proof-configurations/accredited-lawyer/dev/accredited-lawyer.json
+++ b/proof-configurations/accredited-lawyer/dev/accredited-lawyer.json
@@ -18,10 +18,10 @@
           {
             "issuer_did": "RznYFPVhHpYZgsn4Hu3StV",
             "schema_name": "Member Certificate",
-            "schema_version": "0.5.0"
+            "schema_version": "1.0.1"
           },
           {
-            "issuer_did": "RznYFPVhHpYZgsn4Hu3StV",
+            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
             "schema_name": "Member Certificate",
             "schema_version": "1.0.1"
           },
@@ -29,16 +29,6 @@
             "issuer_did": "UUHA3oknprvKrpa7a6sncK",
             "schema_name": "Member Card",
             "schema_version": "1.5.1"
-          },
-          {
-            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
-            "schema_name": "Member Certificate",
-            "schema_version": "0.5.0"
-          },
-          {
-            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
-            "schema_name": "Member Certificate",
-            "schema_version": "1.0.1"
           },
           {
             "issuer_did": "AuJrigKQGRLJajKAebTgWu",

--- a/proof-configurations/accredited-lawyer/test/accredited-lawyer-bcpc.json
+++ b/proof-configurations/accredited-lawyer/test/accredited-lawyer-bcpc.json
@@ -4,7 +4,7 @@
   "subject_identifier": "PPID",
   "proof_request": {
     "name": "Accredited Lawyer with BC Person Credential",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "requested_attributes": [
       {
         "names": [
@@ -15,11 +15,6 @@
           "Member Status Code"
         ],
         "restrictions": [
-          {
-            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
-            "schema_name": "Member Certificate",
-            "schema_version": "0.5.0"
-          },
           {
             "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
             "schema_name": "Member Certificate",

--- a/proof-configurations/accredited-lawyer/test/accredited-lawyer-status.json
+++ b/proof-configurations/accredited-lawyer/test/accredited-lawyer-status.json
@@ -4,7 +4,7 @@
   "subject_identifier": "PPID",
   "proof_request": {
     "name": "Accredited Lawyer Status",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "requested_attributes": [
       {
         "names": [
@@ -13,11 +13,6 @@
           "Member Status Code"
         ],
         "restrictions": [
-          {
-            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
-            "schema_name": "Member Certificate",
-            "schema_version": "0.5.0"
-          },
           {
             "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
             "schema_name": "Member Certificate",

--- a/proof-configurations/accredited-lawyer/test/accredited-lawyer.json
+++ b/proof-configurations/accredited-lawyer/test/accredited-lawyer.json
@@ -3,7 +3,7 @@
   "subject_identifier": "PPID",
   "configuration": {
     "name": "accredited-lawyer",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "requested_attributes": [
       {
         "names": [
@@ -14,11 +14,6 @@
           "Member Status Code"
         ],
         "restrictions": [
-          {
-            "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
-            "schema_name": "Member Certificate",
-            "schema_version": "0.5.0"
-          },
           {
             "issuer_did": "DZBaHghKsVHcJoiwkykG3r",
             "schema_name": "Member Certificate",


### PR DESCRIPTION
Remove restrictions for old, unused credentials to limit proof size - workaround for https://github.com/bcgov/vc-authn-oidc/issues/504

Changes have been deployed to both `dev` and `test`.