### PR TITLE
Add Candy Prod as read-only to the ledger list

### DIFF
--- a/helm-values/traction/values-sandbox.yaml
+++ b/helm-values/traction/values-sandbox.yaml
@@ -14,6 +14,10 @@ acapy:
       genesis_url: "http://test.bcovrin.vonx.io/genesis"
       endorser_did: "DfQetNSm7gGEHuzfUvpfPn"
       endorser_alias: "bcovrin-test-endorser"
+    - id: candy-prod
+      is_production: true
+      is_write: false
+      genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/prod/pool_transactions_genesis"
   plugin-config.yml:
     traction_innkeeper:
       innkeeper_wallet:

--- a/helm-values/traction/values-test.yaml
+++ b/helm-values/traction/values-test.yaml
@@ -15,6 +15,10 @@ acapy:
       genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/test/pool_transactions_genesis"
       endorser_did: "8pcyugH47GpPocmz9AxxDF"
       endorser_alias: "candy-test-endorser"
+    - id: candy-prod
+      is_production: true
+      is_write: false
+      genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/prod/pool_transactions_genesis"
     - id: sovrin-testnet
       is_production: true
       is_write: true


### PR DESCRIPTION
For Traction **sandbox** and **test** envs we would like to have Candy PROD as a read-only ledger available.
This allows presentation request testing of things like the Person Credential in Traction envs.

The ledger does not appear to the user as a connectable ledger in the Tenant UI, as there's no Endorser details. (not that the user would be able to write in that case anyways)