### PR TITLE
Fix showcase-person proof to use production showcase credential.

### DIFF
--- a/proof-configurations/showcase-person/dev/showcase-person.json
+++ b/proof-configurations/showcase-person/dev/showcase-person.json
@@ -22,7 +22,7 @@
                 "restrictions": [
                     {
                         "schema_name": "Person",
-                        "issuer_did": "M6dhuFj5UwbhWkSLmvYSPc"
+                        "issuer_did": "QEquAHkM35w4XVT3Ku5yat"
                     },
                     {
                         "schema_name": "Person",


### PR DESCRIPTION
I had previously changed the DIDs, but used the test showcase instead of the production showcase one. This fixes it (already applied to VC-AuthN).