### PR TITLE
Add all CANdy ledgers in read only mode to sandbox

### DIFF
--- a/helm-values/traction/values-sandbox.yaml
+++ b/helm-values/traction/values-sandbox.yaml
@@ -14,6 +14,14 @@ acapy:
       genesis_url: "http://test.bcovrin.vonx.io/genesis"
       endorser_did: "DfQetNSm7gGEHuzfUvpfPn"
       endorser_alias: "bcovrin-test-endorser"
+    - id: candy-dev
+      is_production: true
+      is_write: false
+      genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/dev/pool_transactions_genesis"
+    - id: candy-test
+      is_production: true
+      is_write: false
+      genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/test/pool_transactions_genesis"
     - id: candy-prod
       is_production: true
       is_write: false


### PR DESCRIPTION
Add all CANdy ledgers in read-only mode to sandbox traction deployment, so that proof-requests can be satisfied by credentials on rooted on those ledgers.

This will be applied nect time the sandbox is reset (likely August 1st). c.c.: @cvarjao @jleach 