### PR TITLE
Reorganized ledger configs to match documentation

### DIFF
--- a/helm-values/traction/values-development.yaml
+++ b/helm-values/traction/values-development.yaml
@@ -1,35 +1,61 @@
-ingressSuffix: -prod.apps.silver.devops.gov.bc.ca
+ingressSuffix: -dev.apps.silver.devops.gov.bc.ca
 acapy:
+  image:
+    pullPolicy: Always
+  secret:
+    adminApiKey:
+      generated: true
+    pluginInnkeeper:
+      generated: true
   ledgers.yml:
+    - id: bcovrin-test
+      is_production: true
+      is_write: true
+      genesis_url: "http://test.bcovrin.vonx.io/genesis"
+      endorser_did: "DfQetNSm7gGEHuzfUvpfPn"
+      endorser_alias: "bcovrin-test-endorser"
+    - id: candy-dev
+      is_production: true
+      is_write: true
+      genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/dev/pool_transactions_genesis"
+      endorser_did: "85DZerr49BLCuG5wWyDviy"
+      endorser_alias: "candy-dev-endorser"
+    - id: candy-test
+      is_production: true
+      is_write: false
+      genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/test/pool_transactions_genesis"
     - id: candy-prod
       is_production: true
-      is_write: true
+      is_write: false
       genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/prod/pool_transactions_genesis"
-      endorser_did: "LTNyw5R14J66CrF7tmV3i8"
-      endorser_alias: "candy-prod-endorser"
-    - id: sovrin-mainnet
+    - id: sovrin-testnet
       is_production: true
       is_write: true
+      genesis_url: "https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis"
+      endorser_did: "EZpKx6nT56Hv83JmNz7ik8"
+      endorser_alias: "sovrin-testnet-endorser"
+    - id: sovrin-mainnet
+      is_production: true
+      is_write: false
       genesis_url: "https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_live_genesis"
-      endorser_did: "65ZC9nkjXBzgsh1cgfkkBB"
-      endorser_alias: "sovrin-mainnet-endorser"
   plugin-config.yml:
     traction_innkeeper:
       innkeeper_wallet:
-        print_key: false
-        print_token: false
+        print_key: true
+        print_token: true
         connect_to_endorser:
-          - endorser_alias: candy-prod-endorser
-            ledger_id: candy-prod
-          - endorser_alias: sovrin-mainnet
-            ledger_id: sovrin-mainnet
+          - endorser_alias: bcovrin-test-endorser
+            ledger_id: bcovrin-test
+          - endorser_alias: candy-dev-endorser
+            ledger_id: candy-dev
+          - endorser_alias: sovrin-testnet-endorser
+            ledger_id: sovrin-testnet
         create_public_did:
-          - candy-prod
-          - sovrin-mainnet
+          - bcovrin-test
+          - candy-dev
+          - sovrin-testnet
       reservation:
-        expiry_minutes: 2880
-        auto_approve: false
-        auto_issuer: false
+        expiry_minutes: 7200
   walletStorageConfig:
     url: traction-database-primary:5432
   walletStorageCredentials:
@@ -38,6 +64,12 @@ acapy:
     secretKeys:
       adminPasswordKey: walletman-password
       userPasswordKey: acapy-password
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
   networkPolicy:
     enabled: true
     ingress:
@@ -46,46 +78,31 @@ acapy:
         network.openshift.io/policy-group: ingress
   resources:
     limits:
-      cpu: 1
-      memory: 500Mi
-    requests:
-      cpu: 250m
-      memory: 250Mi
-  autoscaling:
-    enabled: true
-    minReplicas: 3
-    maxReplicas: 5
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 80
+      cpu: 500m
 tenant_proxy:
+  image:
+    pullPolicy: Always
   networkPolicy:
     enabled: true
     ingress:
       enabled: true
       namespaceSelector:
         network.openshift.io/policy-group: ingress
-  autoscaling:
-    enabled: true
-    minReplicas: 3
-    maxReplicas: 5
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 80
 ui:
   showOIDCReservationLogin: true
-  autoscaling:
-    enabled: true
-    minReplicas: 2
-    maxReplicas: 5
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 80
+  quickConnectEndorserName: "bcovrin-test-endorser"
+  image:
+    pullPolicy: Always
+  ux:
+    infoBanner:
+      message: "Traction DEV Environment"
+      messageLevel: info
+      showMessage: true
   oidc:
     active: true
-    showInnkeeperAdminLogin: true
-    showWritableComponents: false
-    authority: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
-    jwksUri: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
+    authority: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
+    jwksUri: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
     extraQueryParams: '{"kc_idp_hint":"idir"}'
-    realm: "digitaltrust-citz"
     reservationForm: >-
       {
         "formDataSchema": {
@@ -130,7 +147,7 @@ ui:
   smtp:
     server: apps.smtp.gov.bc.ca
     port: 25
-    senderAddress: DoNotReplyTractionPROD@gov.bc.ca
+    senderAddress: DoNotReplyTractionDEV@gov.bc.ca
     innkeeperInbox: "lucas.o'neil@gov.bc.ca,emiliano.sune@quartech.com"
   networkPolicy:
     enabled: true
@@ -138,13 +155,12 @@ ui:
       enabled: true
       namespaceSelector:
         network.openshift.io/policy-group: ingress
-  resources:
-    limits:
-      cpu: 300m
-      memory: 250Mi
-    requests:
-      cpu: 120m
-      memory: 128Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
 ingress:
   annotations:
     route.openshift.io/termination: edge

--- a/helm-values/traction/values-sandbox.yaml
+++ b/helm-values/traction/values-sandbox.yaml
@@ -26,6 +26,14 @@ acapy:
       is_production: true
       is_write: false
       genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/prod/pool_transactions_genesis"
+    - id: sovrin-testnet
+      is_production: true
+      is_write: false
+      genesis_url: "https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis"
+    - id: sovrin-mainnet
+      is_production: true
+      is_write: false
+      genesis_url: "https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_live_genesis"
   plugin-config.yml:
     traction_innkeeper:
       innkeeper_wallet:

--- a/helm-values/traction/values-test.yaml
+++ b/helm-values/traction/values-test.yaml
@@ -25,6 +25,10 @@ acapy:
       genesis_url: "https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis"
       endorser_did: "EZpKx6nT56Hv83JmNz7ik8"
       endorser_alias: "sovrin-testnet-endorser"
+    - id: sovrin-mainnet
+      is_production: true
+      is_write: false
+      genesis_url: "https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_live_genesis"
   plugin-config.yml:
     traction_innkeeper:
       innkeeper_wallet:


### PR DESCRIPTION
Reorganized the ledger configurations for Traction to match what described in the document added [here](https://github.com/bcgov/DITP/pull/90).

@i5okie I added a configuration file for Traction dev here: we should point the dev deployment workflow to pick up files from this repo like we do for `vc-authn` for consistency and delete the dev file in the traction repo. Do we need to update the sync process with our Argo config repo as well, or will the new file here be picked up automagically? See https://github.com/bcgov/trust-over-ip-configurations/issues/203