### PR TITLE
Remove redundant steps from the GitOps Sync

### DIFF
--- a/.github/workflows/gitops_sync.yaml
+++ b/.github/workflows/gitops_sync.yaml
@@ -11,14 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup SSH
-      uses: webfactory/ssh-agent@v0.9.0
-      with:
-        ssh-private-key: ${{ secrets.DITP_GITOPS_REPO_SECRET }}
-
-    - name: Add github.com to known hosts
-      run: ssh-keyscan github.com >> ~/.ssh/known_hosts
-
     - name: Checkout GitOps repo
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Address an issue where the workflow fails when triggered by a PR from a fork.