### PR TITLE
Moved external build resources to repository

### DIFF
--- a/openshift/templates/issuer-agent/Dockerfile
+++ b/openshift/templates/issuer-agent/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.io/bcgovimages/aries-cloudagent:py36-1.16-1_0.7.4
+
+RUN echo "Just pulling the image from Docker Hub"

--- a/openshift/templates/issuer-agent/issuer-agent-build.param
+++ b/openshift/templates/issuer-agent/issuer-agent-build.param
@@ -6,7 +6,7 @@
 NAME=issuer-kit-agent
 APP_NAME=issuer-kit
 APP_GROUP=issuer-kit-runtime
-GIT_REPO_URL=https://github.com/bcgov/issuer-kit.git
+GIT_REPO_URL=https://github.com/bcgov/trust-over-ip-configurations.git
 GIT_REF=main
 SOURCE_CONTEXT_DIR=.
 SOURCE_IMAGE_KIND=DockerImage
@@ -16,5 +16,5 @@ SOURCE_IMAGE_TAG=py36-1.16-1_0.7.4
 # SOURCE_IMAGE_REGISTRY=artifacts.developer.gov.bc.ca/github-docker-remote/
 # SOURCE_IMAGE_NAME=hyperledger/aries-cloudagent-python
 # SOURCE_IMAGE_TAG=py3.9-indy-1.16.0-0.8.1
-DOCKER_FILE_PATH=docker/agent/Dockerfile
+DOCKER_FILE_PATH=openshift/templates/issuer-agent/Dockerfile
 OUTPUT_IMAGE_TAG=latest

--- a/openshift/templates/issuer-wallet/config/postgresql-cfg/autovacuum.conf
+++ b/openshift/templates/issuer-wallet/config/postgresql-cfg/autovacuum.conf
@@ -1,0 +1,31 @@
+#==============================================================================
+# AUTOVACUUM PARAMETERS
+#------------------------------------------------------------------------------
+
+autovacuum = on                         # Enable autovacuum subprocess?  'on'
+                                        # requires track_counts to also be on.
+#log_autovacuum_min_duration = -1       # -1 disables, 0 logs all actions and
+                                        # their durations, > 0 logs only
+                                        # actions running at least this number
+                                        # of milliseconds.
+#autovacuum_max_workers = 3             # max number of autovacuum subprocesses
+                                        # (change requires restart)
+#autovacuum_naptime = 1min              # time between autovacuum runs
+#autovacuum_vacuum_threshold = 50       # min number of row updates before
+                                        # vacuum
+#autovacuum_analyze_threshold = 50      # min number of row updates before
+                                        # analyze
+autovacuum_vacuum_scale_factor = 0.002  # fraction of table size before vacuum
+autovacuum_analyze_scale_factor = 0.001 # fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000  # maximum XID age before forced vacuum
+                                        # (change requires restart)
+#autovacuum_multixact_freeze_max_age = 400000000        # maximum multixact age
+                                        # before forced vacuum
+                                        # (change requires restart)
+#autovacuum_vacuum_cost_delay = 20ms    # default vacuum cost delay for
+                                        # autovacuum, in milliseconds;
+                                        # -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1      # default vacuum cost limit for
+                                        # autovacuum, -1 means use
+                                        # vacuum_cost_limit
+#==============================================================================

--- a/openshift/templates/issuer-wallet/issuer-wallet-build.param
+++ b/openshift/templates/issuer-wallet/issuer-wallet-build.param
@@ -6,9 +6,9 @@
 NAME=issuer-kit-wallet
 APP_NAME=issuer-kit
 APP_GROUP=issuer-kit-storage
-GIT_REPO_URL=https://github.com/bcgov/issuer-kit.git
+GIT_REPO_URL=https://github.com/bcgov/trust-over-ip-configurations.git
 GIT_REF=main
-SOURCE_CONTEXT_DIR=wallet/config
+SOURCE_CONTEXT_DIR=openshift/templates/issuer-wallet/config
 SOURCE_IMAGE_KIND=DockerImage
 SOURCE_IMAGE_REGISTRY=registry.access.redhat.com/
 SOURCE_IMAGE_NAME=rhscl/postgresql-10-rhel7


### PR DESCRIPTION
This PR moves externally referenced build resource into the repository, to make it self-contained for the issuer agent and wallet deployments. Changes have not yet been deployed/tested as I first would like to confirm this is what we want to do.

Resolves #217 