### PR TITLE
Update dev deploy vcauth config for proof type and deep link

### DIFF
--- a/helm-values/vc-authn-oidc/dev.yaml
+++ b/helm-values/vc-authn-oidc/dev.yaml
@@ -6,8 +6,9 @@ image:
 
 acapyTenancyMode: single
 setNonRevoked: true
-useOobPresentProof: false
+useOobPresentProof: true
 useOobLocalDIDService: false
+useUrlDeepLink: true
 controllerCameraRedirectUrl: wallet_howto
 controllerPresentationExpireTime: 300
 useHTTPS: true


### PR DESCRIPTION
Set the configuration (I thought this had been set already in dev but maybe was a default) for VCAuth proof to use out-of-band and the `url` deep link.

Not sure if this will pick up in dev on pushes to `main`? Or do we need a new release.

It would be good to run with these values in dev for a bit for testing with us and other users, we'll want this setup in test and prod soon enough as well.