### PR TITLE
Set vcauth env values for label

### DIFF
--- a/services/vc-authn-oidc/charts/dev/values.yaml
+++ b/services/vc-authn-oidc/charts/dev/values.yaml
@@ -6,6 +6,7 @@ vc-authn-oidc:
     tag: sha-23676cc
   acapyTenancyMode: single
   setNonRevoked: true
+  invitationLabel: BC Gov SSO Service (Dev)
   useOobPresentProof: true
   useOobLocalDIDService: false
   useUrlDeepLink: true

--- a/services/vc-authn-oidc/charts/prod/values.yaml
+++ b/services/vc-authn-oidc/charts/prod/values.yaml
@@ -7,6 +7,7 @@ vc-authn-oidc:
 
   acapyTenancyMode: single
   setNonRevoked: true
+  invitationLabel: BC Gov SSO Service
   useOobPresentProof: false
   useOobLocalDIDService: false
   controllerCameraRedirectUrl: wallet_howto

--- a/services/vc-authn-oidc/charts/test/values.yaml
+++ b/services/vc-authn-oidc/charts/test/values.yaml
@@ -7,6 +7,7 @@ vc-authn-oidc:
 
   acapyTenancyMode: single
   setNonRevoked: true
+  invitationLabel: BC Gov SSO Service (Test)
   useOobPresentProof: false
   useOobLocalDIDService: false
   controllerCameraRedirectUrl: wallet_howto


### PR DESCRIPTION
Prep for eventually allowing the label for who is requesting a proof in our VCAuth environments

![image](https://github.com/user-attachments/assets/79b08dcb-26f7-4a2c-b454-d8909ede98c2)

Using "BC Gov SSO Service" as the label. Can use something else if we want.

Will need a vcauth app release and a helm release that includes this change: https://github.com/bcgov/vc-authn-oidc/pull/627