### PR TITLE
Add registered_urls to LCRB retail store schema

### DIFF
--- a/openshift/templates/orgbook-issuer-controller/config/lcrb/schemas.yml
+++ b/openshift/templates/orgbook-issuer-controller/config/lcrb/schemas.yml
@@ -1,7 +1,7 @@
 # Documentation: https://github.com/bcgov/von-agent-template/tree/master/von-x-agent/config
 
 - name: cannabis-retail-store-licence.lcrb
-  version: '1.0.23'
+  version: '1.0.24'
   description: Cannabis Retail Store Licence Issued by Liquor and Cannabis Regulation Branch
   path: /cannabis-retail-store-licence
   cardinality:
@@ -59,6 +59,11 @@
     country:
       label_en: Country
       description_en: Country
+      data_type: text
+      required: false
+    registered_urls:
+      label_en: Registered URLs
+      description_en: Registered URLs
       data_type: text
       required: false
 - name: cannabis-marketing-licence.lcrb

--- a/openshift/templates/orgbook-issuer-controller/config/lcrb/services.yml
+++ b/openshift/templates/orgbook-issuer-controller/config/lcrb/services.yml
@@ -145,6 +145,17 @@ issuers:
             value:
               input: country
               from: claim
+        - model: attribute
+          fields:
+            type:
+              input: registered_urls
+              from: value
+            format:
+              input: text
+              from: value
+            value:
+              input: registered_urls
+              from: claim
     - schema: cannabis-marketing-licence.lcrb
       description: Cannabis Marketing Licence
       label_en: Cannabis Marketing Licence


### PR DESCRIPTION
Adds the optional `registered_urls` attribute to the Cannabis Retail Store Licence credential.