### PR TITLE
Change endorser multikey value

### DIFF
--- a/services/trustdidweb-server-py/charts/dev/values.yaml
+++ b/services/trustdidweb-server-py/charts/dev/values.yaml
@@ -15,7 +15,7 @@ server:
   host: "registry-dev.apps.silver.devops.gov.bc.ca"
   environment:
     DOMAIN: "registry-dev.apps.silver.devops.gov.bc.ca"
-    ENDORSER_MULTIKEY: "z6MkgSZwM4LUgh2WEtX6TC1FRYevRbgZHkH4ty7e13TiSQy3"
+    ENDORSER_MULTIKEY: "z6Mkqnasc6f4mY1vbpGxCkgZNW5VGumPNQGMyqCpf8zWgUX8"
   autoscaling:
     enabled: true
     minReplicas: 1


### PR DESCRIPTION
Now that acapy v1.0.1 is available in traction dev, I'd like to reprovision the tdw-server dev with my traction tenant.

This will require to use this tenant's public key as the endorser multikey and reset the postgres db