### PR TITLE
Update Acapy image registry in vc-authn-oidc values

### DIFF
--- a/services/vc-authn-oidc/charts/dev/values.yaml
+++ b/services/vc-authn-oidc/charts/dev/values.yaml
@@ -46,7 +46,6 @@ vc-authn-oidc:
       route.openshift.io/termination: edge
   acapy:
     image:
-      repository: ghcr.io/hyperledger/aries-cloudagent-python
       pullPolicy: IfNotPresent
     existingSecret: "vc-authn-oidc-acapy-secret"
     agentSeed:

--- a/services/vc-authn-oidc/charts/prod/values.yaml
+++ b/services/vc-authn-oidc/charts/prod/values.yaml
@@ -53,7 +53,6 @@ vc-authn-oidc:
 
   acapy:
     image:
-      repository: ghcr.io/hyperledger/aries-cloudagent-python
       pullPolicy: IfNotPresent
 
     existingSecret: "vc-authn-oidc-acapy-secret"

--- a/services/vc-authn-oidc/charts/test/values.yaml
+++ b/services/vc-authn-oidc/charts/test/values.yaml
@@ -53,7 +53,6 @@ vc-authn-oidc:
 
   acapy:
     image:
-      repository: ghcr.io/hyperledger/aries-cloudagent-python
       pullPolicy: IfNotPresent
 
     existingSecret: "vc-authn-oidc-acapy-secret"


### PR DESCRIPTION
- Remove `acapy.image.repository` from values to use defaults.