### PR TITLE
Update VCauth Test and Prod config

### DIFF
--- a/services/vc-authn-oidc/charts/prod/values.yaml
+++ b/services/vc-authn-oidc/charts/prod/values.yaml
@@ -8,8 +8,9 @@ vc-authn-oidc:
   acapyTenancyMode: single
   setNonRevoked: true
   invitationLabel: BC Gov SSO Service
-  useOobPresentProof: false
+  useOobPresentProof: true
   useOobLocalDIDService: false
+  useUrlDeepLink: true
   controllerCameraRedirectUrl: wallet_howto
   controllerPresentationExpireTime: 300
   useHTTPS: true

--- a/services/vc-authn-oidc/charts/test/values.yaml
+++ b/services/vc-authn-oidc/charts/test/values.yaml
@@ -8,8 +8,9 @@ vc-authn-oidc:
   acapyTenancyMode: single
   setNonRevoked: true
   invitationLabel: BC Gov SSO Service (Test)
-  useOobPresentProof: false
+  useOobPresentProof: true
   useOobLocalDIDService: false
+  useUrlDeepLink: true
   controllerCameraRedirectUrl: wallet_howto
   controllerPresentationExpireTime: 300
   useHTTPS: true


### PR DESCRIPTION
This will set Test and Prod VCAuthN to
1. Use OOB invitations
2. Use the ?_url deep link format

See "Presentation Request settings" at https://github.com/bcgov/DITP-DevOps/issues/199 for the environment setup at this time. Note test is on VCAuth 2.2.2 and prod on 2.2.1 right now, but that's no difference to this config.

(the app has supported this for a while, should have done it a while ago)
Dev has been running like this for a while and we have all the same use cases set up there (a2a etc) working all good but could be good to do a verification with CSB or other apps in Test before prod.