### PR TITLE
Update target namespace for traction sandbox deployment

### DIFF
--- a/.github/workflows/uninstall_install_sandbox.yaml
+++ b/.github/workflows/uninstall_install_sandbox.yaml
@@ -28,15 +28,15 @@ jobs:
         with:
           openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
-          namespace: ${{ secrets.OPENSHIFT_NAMESPACE }}
+          namespace: ${{ secrets.OPENSHIFT_NAMESPACE_SANDBOX }}
 
       - name: Uninstall Traction via Helm
         run: |
-          helm uninstall traction-sandbox -n ${{ secrets.OPENSHIFT_NAMESPACE }} --wait --timeout=20m || true
+          helm uninstall traction-sandbox -n ${{ secrets.OPENSHIFT_NAMESPACE_SANDBOX }} --wait --timeout=20m || true
 
       - name: Remove Traction Openshift Objects
         run: |
-          oc delete -n ${{ secrets.OPENSHIFT_NAMESPACE }} all,secret,pod,networkpolicy,configmap,pvc --selector "app.kubernetes.io/instance"=traction-sandbox
+          oc delete -n ${{ secrets.OPENSHIFT_NAMESPACE_SANDBOX }} all,secret,pod,networkpolicy,configmap,pvc --selector "app.kubernetes.io/instance"=traction-sandbox
 
       - name: Rocket.Chat Notification
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@1.1.1
@@ -69,7 +69,7 @@ jobs:
         with:
           openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
-          namespace: ${{ secrets.OPENSHIFT_NAMESPACE }}
+          namespace: ${{ secrets.OPENSHIFT_NAMESPACE_SANDBOX }}
       
       - name: Compile banner message
         run: echo "BANNER_MESSAGE=$($GITHUB_WORKSPACE/src/bash/reset-sandbox-date.sh)" >> $GITHUB_ENV
@@ -78,7 +78,7 @@ jobs:
         run: |
           helm repo add traction https://bcgov.github.io/traction 
           helm upgrade --install \
-          -n ${{ secrets.OPENSHIFT_NAMESPACE }} --wait --timeout=7m \
+          -n ${{ secrets.OPENSHIFT_NAMESPACE_SANDBOX }} --wait --timeout=7m \
           -f ./services/traction/sandbox/values.yaml \
           --set ui.ux.infoBanner.message="${BANNER_MESSAGE}" \
           traction-sandbox traction/traction


### PR DESCRIPTION
updated the GHA responsible fro resetting/deploying Traction Sandbox to target the new OpenShift namespace we will be using for it. I created the new secret in the repository settings.