### PR TITLE
Disable sandbox default database creation

### DIFF
--- a/services/traction/sandbox/values.yaml
+++ b/services/traction/sandbox/values.yaml
@@ -143,6 +143,8 @@ ingress:
   annotations:
     route.openshift.io/termination: edge
 postgresql:
+  auth:
+    database: null
   primary:
     persistence:
       size: 5Gi


### PR DESCRIPTION
Required, prior to Traction helm chart release with a permanent fix.