### PR TITLE
Update values for backup-container

### DIFF
--- a/services/orgbook-publisher/charts/dev/values.yaml
+++ b/services/orgbook-publisher/charts/dev/values.yaml
@@ -44,3 +44,6 @@ backend:
       enabled: true
       namespaceSelector:
         network.openshift.io/policy-group: ingress
+mongodb:
+  commonLabels:
+    backup: "true"

--- a/services/orgbook-publisher/charts/prod/values.yaml
+++ b/services/orgbook-publisher/charts/prod/values.yaml
@@ -44,3 +44,6 @@ backend:
       enabled: true
       namespaceSelector:
         network.openshift.io/policy-group: ingress
+mongodb:
+  commonLabels:
+    backup: "true"

--- a/services/orgbook-publisher/charts/test/values.yaml
+++ b/services/orgbook-publisher/charts/test/values.yaml
@@ -44,3 +44,6 @@ backend:
       enabled: true
       namespaceSelector:
         network.openshift.io/policy-group: ingress
+mongodb:
+  commonLabels:
+    backup: "true"

--- a/services/trustdidweb-server-py/charts/dev/values.yaml
+++ b/services/trustdidweb-server-py/charts/dev/values.yaml
@@ -29,10 +29,10 @@ server:
     stabilizationWindowSeconds: 300
   resources:
     limits:
-      cpu: 400m
+      cpu: 500m
       memory: 1600Mi
     requests:
-      cpu: 200m
+      cpu: 300m
       memory: 820Mi
   networkPolicy:
     enabled: true
@@ -41,13 +41,8 @@ server:
       namespaceSelector:
         network.openshift.io/policy-group: ingress
 postgresql:
+  commonLabels:
+    backup: "true"
   primary:
     persistence:
       size: 5Gi
-    resources:
-      limits:
-        cpu: 500m
-        memory: 500Mi
-      requests:
-        cpu: 100m
-        memory: 100Mi

--- a/services/trustdidweb-server-py/charts/prod/values.yaml
+++ b/services/trustdidweb-server-py/charts/prod/values.yaml
@@ -29,10 +29,10 @@ server:
     stabilizationWindowSeconds: 300
   resources:
     limits:
-      cpu: 400m
+      cpu: 500m
       memory: 1600Mi
     requests:
-      cpu: 200m
+      cpu: 300m
       memory: 820Mi
   networkPolicy:
     enabled: true
@@ -41,13 +41,8 @@ server:
       namespaceSelector:
         network.openshift.io/policy-group: ingress
 postgresql:
+  commonLabels:
+    backup: "true"
   primary:
     persistence:
       size: 5Gi
-    resources:
-      limits:
-        cpu: 500m
-        memory: 500Mi
-      requests:
-        cpu: 100m
-        memory: 100Mi

--- a/services/trustdidweb-server-py/charts/test/values.yaml
+++ b/services/trustdidweb-server-py/charts/test/values.yaml
@@ -29,10 +29,10 @@ server:
     stabilizationWindowSeconds: 300
   resources:
     limits:
-      cpu: 400m
+      cpu: 500m
       memory: 1600Mi
     requests:
-      cpu: 200m
+      cpu: 300m
       memory: 820Mi
   networkPolicy:
     enabled: true
@@ -41,13 +41,8 @@ server:
       namespaceSelector:
         network.openshift.io/policy-group: ingress
 postgresql:
+  commonLabels:
+    backup: "true"
   primary:
     persistence:
       size: 5Gi
-    resources:
-      limits:
-        cpu: 500m
-        memory: 500Mi
-      requests:
-        cpu: 100m
-        memory: 100Mi


### PR DESCRIPTION
* Add `backup: true` label to backup-container access based on network policy
* Remove custom resource limits for tdw-server postgresql to reduce (remove) throttling issues - using chart defaults now