### PR TITLE
Consolidated naming for proof-request configurations

### DIFF
--- a/proof-configurations/accredited-lawyer/dev/accredited-lawyer-bcpc.json
+++ b/proof-configurations/accredited-lawyer/dev/accredited-lawyer-bcpc.json
@@ -1,5 +1,5 @@
 {
-  "ver_config_id": "accredited-lawyer-bcpc-dev",
+  "ver_config_id": "accredited-lawyer-bcpc",
   "include_v1_attributes": true,
   "subject_identifier": "PPID",
   "proof_request": {

--- a/proof-configurations/accredited-lawyer/dev/accredited-lawyer-status.json
+++ b/proof-configurations/accredited-lawyer/dev/accredited-lawyer-status.json
@@ -1,5 +1,5 @@
 {
-  "ver_config_id": "accredited-lawyer-status-dev",
+  "ver_config_id": "accredited-lawyer-status",
   "include_v1_attributes": true,
   "subject_identifier": "PPID",
   "proof_request": {

--- a/proof-configurations/accredited-lawyer/dev/accredited-lawyer.json
+++ b/proof-configurations/accredited-lawyer/dev/accredited-lawyer.json
@@ -1,5 +1,5 @@
 {
-  "ver_config_id": "accredited-lawyer-dev",
+  "ver_config_id": "accredited-lawyer",
   "include_v1_attributes": true,
   "subject_identifier": "PPID",
   "proof_request": {

--- a/proof-configurations/accredited-lawyer/test/accredited-lawyer-bcpc.json
+++ b/proof-configurations/accredited-lawyer/test/accredited-lawyer-bcpc.json
@@ -1,5 +1,5 @@
 {
-  "ver_config_id": "accredited-lawyer-bcpc-test",
+  "ver_config_id": "accredited-lawyer-bcpc",
   "include_v1_attributes": true,
   "subject_identifier": "PPID",
   "proof_request": {

--- a/proof-configurations/accredited-lawyer/test/accredited-lawyer-status.json
+++ b/proof-configurations/accredited-lawyer/test/accredited-lawyer-status.json
@@ -1,5 +1,5 @@
 {
-  "ver_config_id": "accredited-lawyer-status-test",
+  "ver_config_id": "accredited-lawyer-status",
   "include_v1_attributes": true,
   "subject_identifier": "PPID",
   "proof_request": {

--- a/proof-configurations/accredited-lawyer/test/accredited-lawyer.json
+++ b/proof-configurations/accredited-lawyer/test/accredited-lawyer.json
@@ -1,5 +1,5 @@
 {
-  "ver_config_id": "accredited-lawyer-test",
+  "ver_config_id": "accredited-lawyer",
   "include_v1_attributes": true,
   "subject_identifier": "PPID",
   "proof_request": {

--- a/proof-configurations/verified-person/dev/verified-person-bcpc.json
+++ b/proof-configurations/verified-person/dev/verified-person-bcpc.json
@@ -1,5 +1,5 @@
 {
-  "ver_config_id": "verified-person-bcpc-dev",
+  "ver_config_id": "verified-person-bcpc",
   "subject_identifier": "",
   "proof_request": {
     "name": "BC Person Credential",

--- a/proof-configurations/verified-person/test/verified-person-bcpc.json
+++ b/proof-configurations/verified-person/test/verified-person-bcpc.json
@@ -1,5 +1,5 @@
 {
-  "ver_config_id": "verified-person-bcpc-test",
+  "ver_config_id": "verified-person-bcpc",
   "subject_identifier": "",
   "proof_request": {
     "name": "BC Person Credential",


### PR DESCRIPTION
Removed suffix for dev and test proof configurations: using the same name across environments is more consistent and leads to less confusion.

Currently both old and new proof-configurations coexist in VC-AuthN (the old IDs have not been removed), but the intention is to eventually get rid of the old style proof-requests and only keep the ones with the newer naming.
