### PR TITLE
Update workflows to build/deploy VC-AuthN

### DIFF
--- a/.github/actions/build_image/action.yaml
+++ b/.github/actions/build_image/action.yaml
@@ -6,29 +6,30 @@ inputs:
     required: false
     default: ''  
   context:
+    description: 'The build context'
     required: true
-    type: string
     default: '.'
   dockerfile:
+    description: 'The Dockerfile to build'
     required: true
-    type: string
     default: ''
   image_name:
+    description: 'The name of the image'
     required: true
-    type: string
     default: ''
   image_tag:
+    description: 'The image tag: determines both the source image tag and the tag applied to the built image'
     required: true
-    type: string
-    default: ''
+    default: 'latest'
   registry:
+    description: 'The registry to push the image to'
     required: true
-    type: string
     default: ghcr.io
   registry_username:
+    description: 'The username to login to the registry'
     required: true
-    type: string
   registry_password:
+    description: 'The password to login to the registry'
     required: true
 
 outputs:

--- a/.github/workflows/build_deploy_vc_authn_test.yaml
+++ b/.github/workflows/build_deploy_vc_authn_test.yaml
@@ -1,4 +1,4 @@
-name: Build and Deploy vc-authn-oidc Test
+name: Build VC-AuthN Release and update ArgoCD configurations for TEST,PROD
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy_vc_authn.yaml
+++ b/.github/workflows/deploy_vc_authn.yaml
@@ -1,4 +1,4 @@
-name: Deploy vc-authn-oidc
+name: Build and Deploy VC-AuthN to DEV
 
 on:
   workflow_dispatch:
@@ -18,22 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Checkout acapy-vc-authn-oidc
-        uses: actions/checkout@v4
-        with:
-          repository: openwallet-foundation/acapy-vc-authn-oidc
-          fetch-depth: 0
-          ref: ${{ github.event.inputs.ref }}
-          sparse-checkout: |
-            charts
-          path: acapy-vc-authn-oidc
-
-      - name: Get short SHA
-        id: slug
-        run: |
-          cd acapy-vc-authn-oidc
-          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
   build_dev:
     needs: [prepare]
     name: "Build BCGov VC-AuthN Controller DEV"
@@ -48,7 +32,7 @@ jobs:
           context: "./services/vc-authn-oidc"
           dockerfile: "./services/vc-authn-oidc/Dockerfile"
           image_name: ${{ github.repository_owner}}/acapy-vc-authn-oidc
-          image_tag: sha-${{ needs.prepare.outputs.short-sha }}
+          image_tag: dev
           registry: ghcr.io
           registry_username: ${{ github.repository_owner}}
           registry_password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Removed the steps to determine the `sha` to be used from the source repo since we can now use tagged images (i.e.: `dev`).