### PR TITLE
Updated Traction to 1.1.2

### DIFF
--- a/services/traction/charts/dev/Chart.yaml
+++ b/services/traction/charts/dev/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: traction
 description: traction - dev
 type: application
-version: "0.3.6"
-appVersion: "1.1.1"
+version: "0.3.7"
+appVersion: "1.1.2"
 dependencies:
   - name: traction
-    version: "0.3.6"
+    version: "0.3.7"
     repository: https://bcgov.github.io/traction

--- a/services/traction/charts/prod/Chart.yaml
+++ b/services/traction/charts/prod/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: traction
 description: traction - production
 type: application
-version: "0.3.6"
-appVersion: "1.1.1"
+version: "0.3.7"
+appVersion: "1.1.2"
 dependencies:
   - name: traction
-    version: "0.3.6"
+    version: "0.3.7"
     repository: https://bcgov.github.io/traction

--- a/services/traction/charts/test/Chart.yaml
+++ b/services/traction/charts/test/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: traction
 type: application
 description: traction - test
-version: "0.3.6"
-appVersion: "1.1.1"
+version: "0.3.7"
+appVersion: "1.1.2"
 dependencies:
   - name: traction
-    version: "0.3.6"
+    version: "0.3.7"
     repository: https://bcgov.github.io/traction


### PR DESCRIPTION
Updated configurations to use latest Traction release (1.1.2).

@i5okie can you please orchestrate the deployment to test/prod once this gets merged? No downtime should be required.