### PR TITLE
Set Time To Live Index values for auth sessions in environments (sessionTimeout helm vals)

### DIFF
--- a/services/vc-authn-oidc/charts/dev/values.yaml
+++ b/services/vc-authn-oidc/charts/dev/values.yaml
@@ -14,6 +14,15 @@ vc-authn-oidc:
   controller:
     cameraRedirectUrl: wallet_howto
     presentationExpireTime: 300
+    sessionTimeout:
+      duration: 86400
+      config:
+        - expired
+        - failed
+        - abandoned
+        - not_started
+        - pending
+        - verified
     templateDirectory: /app/templates
     useConnectionBasedVerification: true
   

--- a/services/vc-authn-oidc/charts/prod/values.yaml
+++ b/services/vc-authn-oidc/charts/prod/values.yaml
@@ -12,6 +12,15 @@ vc-authn-oidc:
   controller:
     cameraRedirectUrl: wallet_howto
     presentationExpireTime: 300
+    sessionTimeout:
+      duration: 86400
+      config:
+        - expired
+        - failed
+        - abandoned
+        - not_started
+        - pending
+        - verified
     templateDirectory: /app/templates
     useConnectionBasedVerification: false
   

--- a/services/vc-authn-oidc/charts/test/values.yaml
+++ b/services/vc-authn-oidc/charts/test/values.yaml
@@ -15,6 +15,15 @@ vc-authn-oidc:
   controller:
     cameraRedirectUrl: wallet_howto
     presentationExpireTime: 300
+    sessionTimeout:
+      duration: 86400
+      config:
+        - expired
+        - failed
+        - abandoned
+        - not_started
+        - pending
+        - verified
     templateDirectory: /app/templates
     useConnectionBasedVerification: false
   


### PR DESCRIPTION
The test and prod envs lack the `auth_session_ttl` Index

Index example in DEV, not sure why/how it got deployed there if it's not in helm vals? (maybe older deployment setting, or testing)
```
  {
    "v": 2,
    "key": {
      "created_at": 1
    },
    "name": "auth_session_ttl",
    "partialFilterExpression": {
      "$or": [
        {
          "proof_status": {
            "$eq": "expired"
          }
        },
        {
          "proof_status": {
            "$eq": "failed"
          }
        },
        {
          "proof_status": {
            "$eq": "abandoned"
          }
        }
      ]
    },
    "expireAfterSeconds": 86400
  }
```

Discussed with @esune , we don't have specific auditing needs to keep everything around. In production records are building up a lot:
<img width="206" height="671" alt="image" src="https://github.com/user-attachments/assets/703fea0f-80c9-42c5-bf6e-6211c3c38e5a" />

So let's just apply the 24 hour session timeout to all statuses